### PR TITLE
Add item.dropOnDeath alternative

### DIFF
--- a/persistent_corpses.lua
+++ b/persistent_corpses.lua
@@ -172,7 +172,8 @@ if (SERVER) then
 			for _, slot in pairs(charInventory.slots) do
 				for _, item in pairs(slot) do
 					if (item.dropOnDeath) then
-						item:Transfer(inventory:GetID(), item.gridX, item.gridY)
+					-- if (!item.noDropOnDeath) then -- Un-comment this line and delete the above if you want all items to drop by default, 
+						item:Transfer(inventory:GetID(), item.gridX, item.gridY) -- but exclude items that have ITEM.noDropOnDeath = true
 					end
 				end
 			end


### PR DESCRIPTION
Add a commented alternative to allow server owners to make all items drop by default and exclude ones they do not want instead by using "ITEM.noDropOnDeath = true" instead of having to add "ITEM.dropOnDeath = true" on every item file.