### PR TITLE
Fixed airwatch lines

### DIFF
--- a/combinevoices.lua
+++ b/combinevoices.lua
@@ -272,5 +272,5 @@ Schema.voices.Add("Airwatch", "0", "Zero.", "npc/overwatch/radiovoice/zero.wav")
 Schema.voices.Add("Airwatch", "Zone", "Zone.", "npc/overwatch/radiovoice/zone.wav")
 
 Schema.voices.AddClass("Airwatch", function(client)
-	return client:Team() == CLASS_SCN
+	return client:IsDispatch()
 end)


### PR DESCRIPTION
Airwatch lines were mistakenly accessed using client:IsTeam() == CLASS_DISP (a remnant from my personal system using a disp faction).

Replaced with client:IsDispatch() which is already defined in sh_player.lua