### PR TITLE
Update Better Crafting plugin

### DIFF
--- a/ixcraft/meta/sh_recipe.lua
+++ b/ixcraft/meta/sh_recipe.lua
@@ -159,7 +159,7 @@ if (SERVER) then
 		if (self.requirements) then
 			local removedItems = {}
 
-			for id, itemTable in pairs(inventory:GetItems()) do
+			for _, itemTable in pairs(inventory:GetItems()) do
 				local uniqueID = itemTable.uniqueID
 
 				if (self.requirements[uniqueID]) then

--- a/ixcraft/meta/sh_recipe.lua
+++ b/ixcraft/meta/sh_recipe.lua
@@ -167,7 +167,7 @@ if (SERVER) then
 					local amount = self.requirements[uniqueID]
 
 					if (amountRemoved < amount) then
-						inventory:Remove(id)
+						itemTable:Remove()
 
 						removedItems[uniqueID] = amountRemoved + 1
 					end


### PR DESCRIPTION
Remove Item from the item object instead of from the inventory object for items in nested inventories.