### PR TITLE
Adds a plugin that edits the death & pain sounds for OTA

### DIFF
--- a/otapain-deathsounds/sh_plugin.lua
+++ b/otapain-deathsounds/sh_plugin.lua
@@ -1,0 +1,7 @@
+PLUGIN.name = "OTA Death Sounds"
+PLUGIN.description = "Plays the appropriate pain or death sound files for when an OTA character is inflicted damage upon or dies."
+PLUGIN.author = "Cepe"
+
+
+ix.util.Include("sv_hooks.lua")
+

--- a/otapain-deathsounds/sv_hooks.lua
+++ b/otapain-deathsounds/sv_hooks.lua
@@ -1,0 +1,22 @@
+
+local PLUGIN = PLUGIN
+
+function PLUGIN:GetPlayerDeathSound(client)
+	if (client:Team() == FACTION_OTA) then
+		local sound = "NPC_CombineS.ElectrocuteScream"
+
+		for k, v in ipairs(player.GetAll()) do
+			if (v:IsCombine()) then
+				v:EmitSound(sound)
+			end
+		end
+
+		return sound
+	end
+end
+
+function PLUGIN:GetPlayerPainSound(client)
+	if (client:Team() == FACTION_OTA) then
+		return "npc/combine_soldier/pain"..math.random(1, 3)..".wav";
+	end
+end


### PR DESCRIPTION
When an OTA character dies or takes damage, they instead play their respective sound files opposed to using Metropolice sounds.