### PR TITLE
Updated weight

### DIFF
--- a/weight/sh_meta.lua
+++ b/weight/sh_meta.lua
@@ -5,6 +5,16 @@ function ITEM:GetWeight()
 	return self:GetData("weight", nil) or self.weight or nil
 end
 
+function ITEM:DropWeight(w)
+	if (self.player) then
+		local weight = w or self:GetWeight()
+
+		if (weight) then
+			self.player:GetCharacter():DropWeight(weight)
+		end
+	end
+end
+
 ix.meta.item = ITEM
 -- ITEM META END --
 
@@ -12,13 +22,18 @@ ix.meta.item = ITEM
 local CHAR = ix.meta.character or {}
 
 function CHAR:Overweight()
-	return self:GetData("carry", 0) > ix.config.Get("maxWeight", 30)
+	return self:GetData("carry", 0) > ix.weight.BaseWeight(self)
 end
 
 function CHAR:CanCarry(item)
-	return ix.weight.CanCarry(item:GetWeight(), self:GetData("carry", 0))
+	return ix.weight.CanCarry(item:GetWeight(), self:GetData("carry", 0), self)
 end
 
+function CHAR:UpdateWeight()
+	ix.weight.Update(self)
+end
+
+-- these are primarily intended as internally used functions, you shouldn't use them in your own code --
 function CHAR:AddCarry(item)
 	self:SetData("carry", math.max(self:GetData("carry", 0) + item:GetWeight(), 0))
 end
@@ -26,6 +41,7 @@ end
 function CHAR:RemoveCarry(item)
 	self:SetData("carry", math.max(self:GetData("carry", 0) - item:GetWeight(), 0))
 end
+-- these are primarily intended as internally used functions, you shouldn't use them in your own code --
 
 function CHAR:DropWeight(weight)
 	self:SetData("carry", math.max(self:GetData("carry", 0) - weight, 0))

--- a/weight/sh_plugin.lua
+++ b/weight/sh_plugin.lua
@@ -33,8 +33,14 @@ function ix.weight.WeightString(weight, imperial)
 	end
 end
 
-function ix.weight.CanCarry(weight, carry) -- Calculate if you are able to carry something.
-	local max = ix.config.Get("maxWeight", 30) + ix.config.Get("maxOverWeight", 20)
+function ix.weight.BaseWeight(character)
+	local base = ix.config.Get("maxWeight", 30)
+
+	return base
+end
+
+function ix.weight.CanCarry(weight, carry, character) -- Calculate if you are able to carry something.
+	local max = ix.weight.BaseWeight(character) + ix.config.Get("maxOverWeight", 20)
 
 	return (weight + carry) <= max
 end
@@ -106,7 +112,7 @@ if (CLIENT) then
 
 				local w, h = panel:GetSize()
 
-				panel:SetTall(h + 25)
+				panel:SetTall(h + 24)
 
 				w = w - 10
 

--- a/weight/sv_plugin.lua
+++ b/weight/sv_plugin.lua
@@ -12,8 +12,12 @@ function ix.weight.CalculateWeight(character) -- Calculates the total weight of 
 	return weight
 end
 
-function PLUGIN:CharacterLoaded(character) -- This is just a safety net to make sure the carry weight data is up-to-date.
+function ix.weight.Update(character) -- Updates the specified character's current carry weight.
 	character:SetData("carry", ix.weight.CalculateWeight(character))
+end
+
+function PLUGIN:CharacterLoaded(character) -- This is just a safety net to make sure the carry weight data is up-to-date.
+	ix.weight.Update(character)
 end
 
 function PLUGIN:CanTransferItem(item, old, inv) -- When a player attempts to take an item out of a container.
@@ -30,9 +34,9 @@ end
 function PLUGIN:OnItemTransferred(item, old, new)
 	if (item:GetWeight()) then
 		if (old.owner and !new.owner) then -- Removing item from inventory.
-			ix.char.loaded[old.owner]:RemoveCarry(item)
+			ix.weight.Update(ix.char.loaded[old.owner])
 		elseif (!old.owner and new.owner) then -- Adding item to inventory.
-			ix.char.loaded[new.owner]:AddCarry(item)
+			ix.weight.Update(ix.char.loaded[new.owner])
 		end
 	end
 end
@@ -40,7 +44,7 @@ end
 function PLUGIN:InventoryItemAdded(old, new, item)
 	if (item:GetWeight()) then
 		if (!old and new.owner) then -- When an item is directly created in their inventory.
-			ix.char.loaded[new.owner]:AddCarry(item)
+			ix.weight.Update(ix.char.loaded[new.owner])
 		end
 	end
 end
@@ -56,4 +60,19 @@ function PLUGIN:CanPlayerTakeItem(client, item)
 			return false
 		end
 	end
+end
+
+function PLUGIN:CanPlayerTradeWithVendor(client, entity, uniqueID, selling)
+	if (!selling) then
+		local item = ix.item.list[uniqueID]
+
+		if (item:GetWeight() and !client:GetCharacter():CanCarry(item)) then
+			client:NotifyLocalized("You are carrying too much weight to buy that.")
+			return false
+		end
+	end
+end
+
+function PLUGIN:CharacterVendorTraded(client, entity, uniqueID, selling)
+	client:GetCharacter():UpdateWeight()
 end


### PR DESCRIPTION
Made some updates to my weight plugin. Decided it was better to completely recalculate a character's carry weight everytime an update is needed instead of just modifying the existing carry value. In the long run this prevents problems where it wasn't being updated correctly. Checks were also added for vendors so if they can't carry an item they are attempting to buy they won't be able to complete the purchase.