### PR TITLE
Update Persistent Corpses plugin

### DIFF
--- a/persistent_corpses.lua
+++ b/persistent_corpses.lua
@@ -237,7 +237,7 @@ else
 				-- restore it as quickly as possible so we aren't being dangerous
 				ix.net[ragdoll:EntIndex()]["player"] = ragdoll.playerVar
 
-				local character = ix.char.loaded[entity:GetNetVar("character", nil)]
+				local character = ix.char.loaded[ragdoll:GetNetVar("character", nil)]
 
 				if (character) then
 					-- group important tooltips together for whatever reason, just copying from tooltip panel

--- a/persistent_corpses.lua
+++ b/persistent_corpses.lua
@@ -229,13 +229,26 @@ else
 			entity.playerVar = entity:GetNetVar("player")
 
 			entity.OnShouldPopulateEntityInfo = function(ragdoll)
+				local index = ragdoll:EntIndex()
 				-- we need to remove the player netvar while we create the tooltip, just so it doesn't create a player based tooltip
-				ix.net[ragdoll:EntIndex()]["player"] = nil
+				if (ix.net[index]) then
+					ix.net[index]["player"] = nil
+
+					-- double down on restoring the player netvar as soon as possible
+					timer.Simple(0, function()
+						if (IsValid(ragdoll)) then
+							ix.net[index]["player"] = nil
+						end
+					end)
+				end
 			end
 
 			entity.OnPopulateEntityInfo = function(ragdoll, container)
+				local index = ragdoll:EntIndex()
 				-- restore it as quickly as possible so we aren't being dangerous
-				ix.net[ragdoll:EntIndex()]["player"] = ragdoll.playerVar
+				if (ix.net[index]) then
+					ix.net[index]["player"] = ragdoll.playerVar
+				end
 
 				local character = ix.char.loaded[ragdoll:GetNetVar("character", nil)]
 

--- a/persistent_corpses.lua
+++ b/persistent_corpses.lua
@@ -177,24 +177,25 @@ if (SERVER) then
 	end
 
 	function PLUGIN:OnPlayerCorpseCreated(client, entity)
-		if (!ix.config.Get("dropItemsOnDeath", false) or !client:GetCharacter()) then
+		if (!client:GetCharacter()) then
 			return
 		end
-		
+
+		local character = client:GetCharacter()
+
 		-- we set character here so we can use the characters data on the tooltip instead of showing the clients data
-		entity:SetNetVar("character", client:GetCharacter():GetID())
+		entity:SetNetVar("character", character:GetID())
 
 		client:SetLocalVar("ragdoll", entity:EntIndex())
 
-		local character = client:GetCharacter()
-		local charInventory = character:GetInventory()
-		local width, height = charInventory:GetSize()
-
-		-- create new inventory
-		local inventory = ix.inventory.Create(width, height, os.time())
-		inventory.noSave = true
-
 		if (ix.config.Get("dropItemsOnDeath")) then
+			local charInventory = character:GetInventory()
+			local width, height = charInventory:GetSize()
+
+			-- create new inventory
+			local inventory = ix.inventory.Create(width, height, os.time())
+			inventory.noSave = true
+
 			for _, slot in pairs(charInventory.slots) do
 				for _, item in pairs(slot) do
 					if (item.bDropOnDeath) then
@@ -206,9 +207,9 @@ if (SERVER) then
 					end
 				end
 			end
-		end
 
-		entity.ixInventory = inventory
+			entity.ixInventory = inventory
+		end
 	end
 
 	function PLUGIN:PlayerUse(client, entity)

--- a/persistent_corpses.lua
+++ b/persistent_corpses.lua
@@ -166,9 +166,6 @@ if (SERVER) then
 		-- remove reference to the player so no more damage can be dealt
 		entity.ixPlayer = nil
 
-		-- we set character here so we can use the characters data on the tooltip instead of showing the clients data
-		entity:SetNetVar("character", client:GetCharacter():GetID())
-
 		self.corpses[#self.corpses + 1] = entity
 
 		-- clean up old corpses after we've added this one
@@ -183,6 +180,9 @@ if (SERVER) then
 		if (!ix.config.Get("dropItemsOnDeath", false) or !client:GetCharacter()) then
 			return
 		end
+		
+		-- we set character here so we can use the characters data on the tooltip instead of showing the clients data
+		entity:SetNetVar("character", client:GetCharacter():GetID())
 
 		client:SetLocalVar("ragdoll", entity:EntIndex())
 

--- a/persistent_corpses.lua
+++ b/persistent_corpses.lua
@@ -237,7 +237,7 @@ else
 					-- double down on restoring the player netvar as soon as possible
 					timer.Simple(0, function()
 						if (IsValid(ragdoll)) then
-							ix.net[index]["player"] = nil
+							ix.net[index]["player"] = ragdoll.playerVar
 						end
 					end)
 				end

--- a/persistent_corpses.lua
+++ b/persistent_corpses.lua
@@ -248,6 +248,14 @@ else
 		end
 	end
 
+	local function GetCharacterName(character)
+		local ourCharacter = LocalPlayer():GetCharacter()
+
+		if (ourCharacter and character and !ourCharacter:DoesRecognize(character)) then
+			return L"unknown"
+		end
+	end
+
 	local injureTextColor = Color(231, 0, 0)
 
 	function PLUGIN:PopulateImportantCorpseTooltip(character, container)
@@ -257,7 +265,7 @@ else
 		-- name
 		local name = container:AddRow("name")
 		name:SetImportant()
-		name:SetText(hook.Run("GetCharacterName", character) or character:GetName())
+		name:SetText(GetCharacterName(character) or character:GetName())
 		name:SetBackgroundColor(color)
 		name:SizeToContents()
 


### PR DESCRIPTION
Makes corpses use character data instead of the player tooltip, not a 100% ideal way of doing it (makes two new hooks) although it is foolproof and works without causing issues.