### PR TITLE
Simple Bodygroup Manager | Better looking version of the currently existing "Bodygroup manager" with some new features and additions

### DIFF
--- a/simple_bodygroup_manager/LICENSE
+++ b/simple_bodygroup_manager/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2024 Bena
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/simple_bodygroup_manager/README.md
+++ b/simple_bodygroup_manager/README.md
@@ -1,0 +1,20 @@
+
+# Simple Bodygroup Manager
+
+Simple plugin that provides users and staff with tools to modify their bodygroups from a fresh-looking menu.
+
+## Features
+- Users can modify their bodygroups from a menu.
+- Staff can modify other's bodygroups as well.
+- Staffs can forbid other players to use the menu with a command so those who don't use it in a correct way just can't use it anymore (same command to reverse the prohibition)
+- Colors can be modified in config.
+- Factions can be added to a ByPass table so that its members can use the menu even if the use of the menu is disabled!
+- Spanish and English translations for *almost* everything
+
+## Installation
+- After downloading the files, just add the folder "simple_bodygroup_manager" to your schema/plugins folder
+
+![Image](https://i.imgur.com/pT5908k.png)
+
+#### Contact: soybena @ Discord
+

--- a/simple_bodygroup_manager/derma/cl_bgmanager.lua
+++ b/simple_bodygroup_manager/derma/cl_bgmanager.lua
@@ -1,0 +1,162 @@
+local PANEL = {}
+
+function PANEL:Init()
+    self:SetSize(ScrW() * 0.5, ScrH() * 0.6)
+    self:Center()
+    self:SetTitle("")
+    self:SetDraggable(true)
+    self:MakePopup()
+
+    self.Paint = function(_, w, h)
+        draw.RoundedBox(15,0,0,w,h, ix.config.Get("colorFondoBGManager"))
+    end
+end
+
+function PANEL:Fill(target)
+    local client = target or LocalPlayer()
+
+    self.headerTitle = self:Add("DLabel")
+    self.headerTitle:SetColor(ix.config.Get("colorEnfasisBGManager"))
+    self.headerTitle:Dock(TOP)
+    self.headerTitle:DockMargin(10,0,0,25)
+    self.headerTitle:SetFont("ixBigFont")
+    self.headerTitle:SetText("Modifying the bodygroups of: " .. client:Name())
+    self.headerTitle:SetContentAlignment(5)
+    self.headerTitle:SizeToContents()
+
+    self.displayCharacter = self:Add("DAdjustableModelPanel")
+    self.displayCharacter:Dock(LEFT)
+    self.displayCharacter:SetSize(ScrW() * 0.25 , ScrH() * 0.6)
+    self.displayCharacter:SetModel(client:GetModel())
+    self.displayCharacter.LayoutEntity = function(ent) return end
+    self.displayCharacter:SetFOV(50)
+
+    self.displayCharacter.Entity:SetSkin(client:GetSkin())
+
+    local colorJugador = client:GetPlayerColor()
+    self.displayCharacter.Entity.GetPlayerColor = function() return colorJugador end
+
+    for i = 0, client:GetNumBodyGroups() - 1 do
+        self.displayCharacter:GetEntity():SetBodygroup(i, client:GetBodygroup(i))
+    end
+
+    self.displayCharacter.Entity:SetAngles(Angle(0, 180, 0))
+    self.displayCharacter:SetDirectionalLight(BOX_BACK, color_white)
+
+    -- Forzamos un click izquierdo en el panel para que se muestre el modelo desde un inicio
+    self.displayCharacter:OnMousePressed(MOUSE_LEFT)
+    timer.Simple(0.1, function()
+        self.displayCharacter:OnMouseReleased(MOUSE_LEFT)
+    end)
+
+    self.contenedorBg = self:Add("DScrollPanel")
+    self.contenedorBg:SetWide(self:GetWide() * 0.25)
+    self.contenedorBg:Dock(FILL)
+
+    self.barraContenedor = self.contenedorBg:GetVBar()
+    self.barraContenedor.btnGrip.Paint = function(_, w, h)
+        draw.RoundedBox(30,0,0,w * 0.2,h,ix.config.Get("colorEnfasisBGManager"))
+    end
+    self.contenedorBg.Paint = function(_, w, h)
+        draw.RoundedBox(15,0,0,w,h,Color(49, 49, 49, 100))
+    end
+
+
+    self.skinLabel = self.contenedorBg:Add("ixLabel")
+    self.skinLabel:Dock(TOP)
+    self.skinLabel:DockMargin(10, 10, 0, 5)
+    self.skinLabel:SetFont("ixMediumFont")
+    self.skinLabel:SetText("Skin")
+    self.skinLabel:SetTextColor(ix.config.Get("colorEnfasisBGManager"))
+    self.skinLabel:SetContentAlignment(7)
+
+    self.skinSlider = self.contenedorBg:Add("DNumSlider")
+    self.skinSlider:Dock(TOP)
+    self.skinSlider:SetContentAlignment(7)
+    self.skinSlider:DockMargin(10, 10, 0, 5)
+    self.skinSlider:SetMin(0)
+    self.skinSlider:SetMax(client:SkinCount())
+    self.skinSlider:SetDecimals(0)
+    self.skinSlider.OnValueChanged = function(_, val)
+        self.displayCharacter.Entity:SetSkin(val)
+    end
+
+    for _, subPanel in ipairs(self.skinSlider:GetChildren()) do
+        if (subPanel:GetName() != "DLabel") then continue end
+        subPanel:ToggleVisible()
+    end
+
+    for _, bgData in ipairs(client:GetBodyGroups()) do
+        if (#bgData.submodels < 1) then continue end
+        local nombreBodygroup = self.contenedorBg:Add("ixLabel")
+        nombreBodygroup:Dock(TOP)
+        nombreBodygroup:DockMargin(10, 10, 0, 5)
+        nombreBodygroup:SetFont("ixMediumFont")
+        nombreBodygroup:SetText(bgData.name)
+        nombreBodygroup:SetTextColor(ix.config.Get("colorEnfasisBGManager"))
+        nombreBodygroup:SetContentAlignment(7)
+
+        local bgBarra = self.contenedorBg:Add("DNumSlider")
+        bgBarra:Dock(TOP)
+        bgBarra:SetContentAlignment(7)
+        bgBarra:DockMargin(10, 10, 0, 5)
+        bgBarra:SetMin()
+        bgBarra:SetMax(bgData.num - 1)
+        bgBarra:SetDecimals(0)
+
+        -- Para cada barra, ponemos default el valor que tiene actualmente el jugador
+        bgBarra:SetValue(client:GetBodygroup(bgData.id))
+
+        -- Ocultamos el título y scratch de la barra deslizadora
+        for _, subPanel in ipairs(bgBarra:GetChildren()) do
+            if (subPanel:GetName() != "DLabel") then continue end
+            subPanel:SetVisible(false)
+        end
+
+        -- Realtime update of the bodygroups in the preview
+        bgBarra.OnValueChanged = function(_, val)
+            self.displayCharacter.Entity:SetBodygroup(bgData.id, val)
+        end
+    end
+
+
+
+    self.buttonContainer = self:Add("DPanel")
+    self.buttonContainer:Dock(BOTTOM)
+    self.buttonContainer:DockMargin(0, 10, 0, 10)
+    self.buttonContainer.Paint = function() return end
+
+    self.button = self.buttonContainer:Add("DButton")
+    self.button:Dock(FILL)
+    self.button:SetText("Save")
+    self.button:SetFont("ixMediumFont")
+    self.button:SetContentAlignment(5)
+    self.button:SizeToContents()
+
+    self.button.Paint = function(_, w, h)
+        draw.RoundedBox(5,0,0,w,h, ix.config.Get("saveButtonColor"))
+    end
+
+    self.button.DoClick = function()
+        local tblBodygroups = {}
+        for i = 0, self.displayCharacter.Entity:GetNumBodyGroups() - 1 do
+            tblBodygroups[i] = self.displayCharacter.Entity:GetBodygroup(i)
+        end
+
+        net.Start("SBMSaveBodygroups")
+            net.WritePlayer(target)
+            net.WriteTable(tblBodygroups)
+        net.SendToServer()
+
+        if (LocalPlayer() == client) then
+            LocalPlayer():NotifyLocalized("selfBodygroupsModified")
+        else
+            LocalPlayer():NotifyLocalized("userBodygroupsModified", client:Name())
+        end
+
+        self:Remove()
+    end
+end
+
+
+vgui.Register("ixCambiadorBodygroups", PANEL, "DFrame")

--- a/simple_bodygroup_manager/hooks/sv_hooks.lua
+++ b/simple_bodygroup_manager/hooks/sv_hooks.lua
@@ -1,0 +1,11 @@
+function PLUGIN:PlayerButtonDown(ply, button)
+    if (!ply:GetCharacter()) then return end
+
+    if (button == SBM.config.keyOptions.key) then
+        if (SBM.banned[ply:SteamID()]) then return end
+        if (!ix.config.Get("allowKeyUseBGManager") and !SBM.config.keyOptions.factionBypass[ix.faction.Get(ply:GetCharacter():GetFaction()).uniqueID]) then return end
+        net.Start("SBMOpenMenu")
+            net.WritePlayer(ply)
+        net.Send(ply)
+    end
+end

--- a/simple_bodygroup_manager/languages/sh_english.lua
+++ b/simple_bodygroup_manager/languages/sh_english.lua
@@ -1,0 +1,15 @@
+LANGUAGE = {
+    cfgColorFondoBGManager = "Background color",
+    cfgColorEnfasisBGManager = "Enphasis color",
+    cfgAllowKeyUseBGManager = "Allow key-use",
+    cfgSaveButtonColor = "Save button color",
+
+    cmdBanKeyUseSBMDesc = "Forbid a player to open the menu with a key even if it's turned on",
+    cmdEditUserBodygroups = "Modify a target's bodygroups from the menu.",
+    cmdBanKeyUseSBMUnbanned = "%s has unforbidden %s from using the key to open the bodygroup menu.",
+    cmdBanKeyUseSBMBanned = "%s has forbid %s from using the key to open the bodygroup managing menu.",
+
+    selfBodygroupsModified = "You saved your bodygroups!",
+    userBodygroupsModified = "You modified %s's bodygroups.",
+
+}

--- a/simple_bodygroup_manager/languages/sh_spanish.lua
+++ b/simple_bodygroup_manager/languages/sh_spanish.lua
@@ -1,0 +1,15 @@
+LANGUAGE = {
+    cfgColorFondoBGManager = "Color del fondo",
+    cfgColorEnfasisBGManager = "Color del enfasis",
+    cfgAllowKeyUseBGManager = "Permitir uso con tecla",
+    cfgSaveButtonColor = "Color del botón de guardado",
+
+    cmdBanKeyUseSBMDesc = "Impide que un jugador pueda utilizar el menú con la tecla aunque esté activado",
+    cmdEditUserBodygroups = "Modifica los bodygroups de un usuario desde el menú.",
+    cmdBanKeyUseSBMUnbanned = "El staff %s ha retirado la restricción del uso de tecla a %s.",
+    cmdBanKeyUseSBMBanned = "El staff %s ha restringido a %s de abrir el gestor de bodygroups con la tecla de acceso rápido.",
+
+    selfBodygroupsModified = "¡Has guardado tu apariencia!",
+    userBodygroupsModified = "Has modificado la apariencia de %s.",
+
+}

--- a/simple_bodygroup_manager/net/cl_net.lua
+++ b/simple_bodygroup_manager/net/cl_net.lua
@@ -1,0 +1,4 @@
+net.Receive("SBMOpenMenu", function()
+    local target = net.ReadPlayer()
+    vgui.Create("ixCambiadorBodygroups"):Fill(target)
+end)

--- a/simple_bodygroup_manager/net/sv_net.lua
+++ b/simple_bodygroup_manager/net/sv_net.lua
@@ -1,0 +1,17 @@
+util.AddNetworkString("SBMOpenMenu")
+util.AddNetworkString("SBMSaveBodygroups")
+
+
+net.Receive("SBMSaveBodygroups", function(_, ply)
+    local target = net.ReadPlayer()
+    local tblBodygroups = net.ReadTable()
+
+    if (!target or !target:IsPlayer() or !target:GetCharacter()) then return end
+
+    for id, val in ipairs(tblBodygroups) do
+        target:SetBodygroup(id, val)
+    end
+
+    target:GetCharacter():SetData("groups", tblBodygroups)
+
+end)

--- a/simple_bodygroup_manager/sh_configs.lua
+++ b/simple_bodygroup_manager/sh_configs.lua
@@ -1,0 +1,15 @@
+ix.config.Add("colorFondoBGManager", Color(24,23,21),"Color del fondo del menú de cambio de bodygroups", nil, {
+    category = "Simple Bodygroup Manager"
+})
+
+ix.config.Add("colorEnfasisBGManager", Color(255,255,255),"Color del enfasis del menú de cambio de bodygroups", nil, {
+    category = "Simple Bodygroup Manager"
+})
+
+ix.config.Add("allowKeyUseBGManager", true, "Permite que los usuarios abran el menú pulsando una tecla", nil, {
+    category = "Simple Bodygroup Manager"
+})
+
+ix.config.Add("saveButtonColor", Color(33,107,27), "Color del botón de guardado", nil, {
+    category = "Simple Bodygroup Manager"
+})

--- a/simple_bodygroup_manager/sh_plugin.lua
+++ b/simple_bodygroup_manager/sh_plugin.lua
@@ -1,0 +1,89 @@
+local PLUGIN = PLUGIN
+
+PLUGIN.name = "Simple Bodygroup Manager"
+PLUGIN.description = "Allow clients to modify their bodygroups and staff to modify user's easily"
+PLUGIN.author = "Bena"
+PLUGIN.schema = "Any"
+PLUGIN.license = [[
+Copyright 2024 Bena
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+]]
+
+
+-- Global so that we can use this wherever we want even if outside the plugin
+SBM = SMB or ix.data.Get("sbmData", {})
+SBM.config = SBM.config or {}
+SBM.banned = SBM.banned or {} -- List of STEAMIDs that no matter what will not be able to use the menu without interacting with the entity
+SBM.config.keyOptions = {
+    factionBypass = { -- Factions that would be able to use the menu by using the key even if the 'allowKeyUse' setting above is set to false by adding its unique id
+        ministerio = true -- Just an example of how to add factions. Just add the uniqueID
+    },
+    key = KEY_F9
+
+}
+
+
+ix.command.Add("ForbidKey", {
+    description = "@cmdBanKeyUseSBMDesc",
+    adminOnly = true,
+    arguments = ix.type.player,
+    argumentNames = {"Target"},
+    OnRun = function(self, client, target)
+        if (!target) then return end
+
+        if (SBM.banned[target:SteamID()]) then
+            SBM.banned[target:SteamID()] = nil
+            for _, ply in player.Iterator() do
+                if !ply:IsAdmin() then continue end
+                ply:NotifyLocalized("cmdBanKeyUseSBMUnbanned", client:SteamName(), target:Name())
+            end
+        else
+            SBM.banned[target:SteamID()] = true
+            for _, ply in player.Iterator() do
+                if !ply:IsAdmin() then continue end
+                ply:NotifyLocalized("cmdBanKeyUseSBMBanned", client:SteamName(), target:Name())
+            end
+        end
+
+        PLUGIN:SaveData()
+    end
+})
+
+ix.command.Add("EditUserBodygroups", {
+    description = "@cmdEditUserBodygroups",
+    adminOnly = true,
+    arguments = ix.type.player,
+    argumentNames = {"Target"},
+    OnRun = function(self, client, target)
+        if (!target) then return end
+
+        net.Start("SBMOpenMenu")
+            net.WritePlayer(target)
+        net.Send(client)
+
+    end
+})
+
+-- Serverside plugin
+ix.util.Include("sv_plugin.lua")
+
+-- Configs
+ix.util.Include("sh_configs.lua")
+
+-- Nets
+ix.util.Include("net/sv_net.lua")
+ix.util.Include("net/cl_net.lua")
+
+-- Hooks
+ix.util.Include("hooks/sv_hooks.lua")
+
+-- Dermas
+ix.util.Include("derma/cl_bgmanager.lua")
+

--- a/simple_bodygroup_manager/sv_plugin.lua
+++ b/simple_bodygroup_manager/sv_plugin.lua
@@ -1,0 +1,3 @@
+function PLUGIN:SaveData()
+    ix.data.Set("sbmData", SBM)
+end


### PR DESCRIPTION
# Simple Bodygroup Manager

Simple plugin that provides users and staff with tools to modify their bodygroups from a fresh-looking menu.

## Features
- Users can modify their bodygroups from a menu.
- Staff can modify other's bodygroups as well.
- Staffs can forbid other players to use the menu with a command so those who don't use it in a correct way just can't use it anymore (same command to reverse the prohibition)
- Colors can be modified in config.
- Factions can be added to a ByPass table so that its members can use the menu even if the use of the menu is disabled!
- Spanish and English translations for *almost* everything
- You can also modify the 'Skin' of the model!

Default using key is F9. 


![Image](https://i.imgur.com/pT5908k.png)


